### PR TITLE
snapshot: attach iteration_id and enforce Header→Data→Tail ordering

### DIFF
--- a/src/k2eg/controller/node/worker/snapshot/BackTimedBufferedSnapshotOpInfo.cpp
+++ b/src/k2eg/controller/node/worker/snapshot/BackTimedBufferedSnapshotOpInfo.cpp
@@ -150,5 +150,6 @@ SnapshotSubmissionShrdPtr BackTimedBufferedSnapshotOpInfo::getData()
             header_sent = false; // Reset header for the next window
         }
     }
-    return MakeSnapshotSubmissionShrdPtr(std::chrono::steady_clock::now(),std::move(result), type);
+    // Iteration id is assigned by the scheduler; initialize as 0 here.
+    return MakeSnapshotSubmissionShrdPtr(std::chrono::steady_clock::now(), std::move(result), type, 0);
 }

--- a/src/k2eg/controller/node/worker/snapshot/ContinuousSnapshotManager.cpp
+++ b/src/k2eg/controller/node/worker/snapshot/ContinuousSnapshotManager.cpp
@@ -456,6 +456,32 @@ void ContinuousSnapshotManager::expirationCheckerLoop()
                         metrics.incrementCounter(k2eg::service::metric::INodeControllerMetricCounterType::SnapshotEventCounter,
                                                  submission_shard_ptr->snapshot_events.size());
                     }
+                    // Determine iteration id and set per-iteration gates/counters
+                    int64_t scheduled_iteration_id = 0;
+                    if ((submission_shard_ptr->submission_type & SnapshotSubmissionType::Header) != SnapshotSubmissionType::None)
+                    {
+                        scheduled_iteration_id = iteration_sync_->acquireIteration(s_op_ptr->cmd->snapshot_name);
+                        active_iteration_id_[s_op_ptr->cmd->snapshot_name] = scheduled_iteration_id;
+                        s_op_ptr->beginHeaderGate(scheduled_iteration_id);
+                    }
+                    else
+                    {
+                        auto it = active_iteration_id_.find(s_op_ptr->cmd->snapshot_name);
+                        if (it != active_iteration_id_.end())
+                            scheduled_iteration_id = it->second;
+                        else
+                            scheduled_iteration_id = 0; // should not happen if scheduling order is correct
+                    }
+
+                    // Always attach resolved iteration id to the submission for task-side use
+                    submission_shard_ptr->iteration_id = scheduled_iteration_id;
+
+                    // If Data is present, record it so Tail can wait later. Count per submission batch.
+                    if ((submission_shard_ptr->submission_type & SnapshotSubmissionType::Data) != SnapshotSubmissionType::None &&
+                        !submission_shard_ptr->snapshot_events.empty())
+                    {
+                        s_op_ptr->dataScheduled(scheduled_iteration_id);
+                    }
                     thread_pool->detach_task(
                         [this, s_op_ptr, submission_shard_ptr, last_submission]() mutable
                         {
@@ -464,6 +490,8 @@ void ContinuousSnapshotManager::expirationCheckerLoop()
                         });
                     if (to_continue)
                     {
+                        // Cleanup active iteration tracking for this snapshot
+                        active_iteration_id_.erase(s_op_ptr->cmd->snapshot_name);
                         continue; // Skip the increment, as we already erased the current item.
                     }
                 }
@@ -511,20 +539,13 @@ void SnapshotSubmissionTask::operator()()
     if (!thread_index.has_value())
         return;
     auto    snap_ts = CHRONO_TO_UNIX_INT64(submission_shrd_ptr->snap_time);
-    int64_t current_iteration = 0;
+    int64_t current_iteration = submission_shrd_ptr->iteration_id;
 
-    // HEADER: This is the start of a new logical iteration.
-    if ((submission_shrd_ptr->submission_type & SnapshotSubmissionType::Header) != SnapshotSubmissionType::None)
+    // Iteration id is resolved at scheduling and attached to the submission.
+    if (current_iteration == 0)
     {
-        // Acquire the lock and get the new, unique iteration number.
-        current_iteration = iteration_sync_.acquireIteration(snapshot_command_info->cmd->snapshot_name);
-        // Store it in the shared atomic variable for other tasks to see.
-        snapshot_command_info->snapshot_iteration_index.store(current_iteration);
-    }
-    else
-    {
-        // DATA or TAIL: This task belongs to an existing iteration. Load its number.
-        current_iteration = snapshot_command_info->snapshot_iteration_index.load();
+        logger->logMessage(STRING_FORMAT("Snapshot %1% missing iteration id on submission; skipping.", snapshot_command_info->cmd->snapshot_name), LogLevel::ERROR);
+        return;
     }
 
     // This guard ensures that this task is counted, and its completion is always registered.
@@ -538,11 +559,17 @@ void SnapshotSubmissionTask::operator()()
                                                             snapshot_command_info->cmd->snapshot_name, serialized_header_message),
                                {{"k2eg-ser-type", serialization_to_string(snapshot_command_info->cmd->serialization)}});
         logger->logMessage(STRING_FORMAT("[Header] Snapshot %1% iteration %2% started", snapshot_command_info->cmd->snapshot_name % current_iteration), LogLevel::DEBUG);
+
+        // Release header gate so Data submissions can proceed
+        snapshot_command_info->completeHeaderGate(current_iteration);
     }
 
     if ((submission_shrd_ptr->submission_type & SnapshotSubmissionType::Data) != SnapshotSubmissionType::None &&
         !submission_shrd_ptr->snapshot_events.empty())
     {
+        // Ensure header was published for this iteration before sending any data
+        snapshot_command_info->waitForHeaderGate(current_iteration);
+
         // Data processing logic is unchanged. It can run concurrently with other data tasks.
         std::set<std::string> pv_names_published;
         for (auto& event : submission_shrd_ptr->snapshot_events)
@@ -568,10 +595,14 @@ void SnapshotSubmissionTask::operator()()
                                          snapshot_command_info->cmd->snapshot_name % current_iteration %
                                              submission_shrd_ptr->snapshot_events.size() % pv_names_published.size() % get_pv_names(pv_names_published)),
                            LogLevel::DEBUG);
+        // Mark data submission as completed for this iteration
+        snapshot_command_info->dataCompleted(current_iteration);
     }
 
     if ((submission_shrd_ptr->submission_type & SnapshotSubmissionType::Tail) != SnapshotSubmissionType::None)
     {
+        // Ensure all data submissions for this iteration are fully published before sending Tail
+        snapshot_command_info->waitDataDrained(current_iteration);
         logger->logMessage(STRING_FORMAT("[Tail] Snapshot %1% iteration %2% completed", snapshot_command_info->cmd->snapshot_name % current_iteration), LogLevel::DEBUG);
         auto serialized_completion_message = serialize(RepeatingSnaptshotCompletion{2, 0, "", snapshot_command_info->cmd->snapshot_name, snap_ts, current_iteration},
                                                        snapshot_command_info->cmd->serialization);
@@ -589,6 +620,8 @@ void SnapshotSubmissionTask::operator()()
             snapshot_command_info->removal_promise.set_value(); // Notify that the snapshot is fully removed.
         }
     }
+
+    // No explicit header gate clear is needed; gate resets on the next Header scheduling
 }
 
 #pragma region snapshot iteration synchronization
@@ -679,6 +712,8 @@ void SnapshotIterationSynchronizer::markTailProcessed(const std::string& snapsho
         }
     }
 }
+
+// dataStarted/dataCompleted/waitDataDrained now managed inside SnapshotOpInfo
 
 // Private helper to release the lock and notify the next waiting iteration.
 void SnapshotIterationSynchronizer::releaseLock(const std::string& snapshot_name, uint64_t iteration_id_to_clear)

--- a/src/k2eg/controller/node/worker/snapshot/SnapshotOpInfo.h
+++ b/src/k2eg/controller/node/worker/snapshot/SnapshotOpInfo.h
@@ -6,29 +6,59 @@
 #include <atomic>
 #include <k2eg/service/epics/EpicsData.h>
 
+#include <condition_variable>
+#include <future>
 #include <k2eg/controller/node/worker/CommandWorker.h>
+#include <mutex>
+#include <unordered_map>
 
 namespace k2eg::controller::node::worker::snapshot {
 
+/**
+ * @brief Define the parts of a snapshot submission.
+ * @details Flags describing which logical section(s) are contained in a single
+ *          submission batch produced by a snapshot op. Values can be OR'ed.
+ *          - Header: marks the beginning of an iteration and carries metadata.
+ *          - Data: carries one or more PV events belonging to the iteration.
+ *          - Tail: marks the end of an iteration and carries completion info.
+ */
 enum class SnapshotSubmissionType
 {
-    None = 0,
-    Header = 1 << 0,
-    Data = 1 << 1,
-    Tail = 1 << 2
+    None = 0,        /**< No content. */
+    Header = 1 << 0, /**< Submit the iteration header. */
+    Data = 1 << 1,   /**< Submit PV data for the iteration. */
+    Tail = 1 << 2    /**< Submit the iteration completion (tail). */
 };
 
 // Bitwise operators for SnapshotSubmissionType
+/**
+ * @brief Combine flags.
+ * @param a Left-hand flag value.
+ * @param b Right-hand flag value.
+ * @return Bitwise OR of the two flags.
+ */
 inline SnapshotSubmissionType operator|(SnapshotSubmissionType a, SnapshotSubmissionType b)
 {
     return static_cast<SnapshotSubmissionType>(static_cast<int>(a) | static_cast<int>(b));
 }
 
+/**
+ * @brief Intersect flags.
+ * @param a Left-hand flag value.
+ * @param b Right-hand flag value.
+ * @return Bitwise AND of the two flags.
+ */
 inline SnapshotSubmissionType operator&(SnapshotSubmissionType a, SnapshotSubmissionType b)
 {
     return static_cast<SnapshotSubmissionType>(static_cast<int>(a) & static_cast<int>(b));
 }
 
+/**
+ * @brief In-place combine flags.
+ * @param a Left-hand flag reference to update.
+ * @param b Right-hand flag value.
+ * @return Updated left-hand flag.
+ */
 inline SnapshotSubmissionType& operator|=(SnapshotSubmissionType& a, SnapshotSubmissionType b)
 {
     a = a | b;
@@ -38,93 +68,252 @@ inline SnapshotSubmissionType& operator|=(SnapshotSubmissionType& a, SnapshotSub
 // forward declaration
 class SnapshotOpInfo;
 
-// the class for the submition of a snapshot
+/**
+ * @brief Hold one snapshot submission batch.
+ * @details Move-only container produced by a SnapshotOpInfo implementation
+ *          when the operation window expires or is triggered. It carries
+ *          the events and which sections are present (header/data/tail).
+ *          Ownership of events remains shared via shared_ptr.
+ */
 class SnapshotSubmission
 {
 public:
-    std::chrono::steady_clock::time_point                 snap_time; // time point for the snapshot
+    /** @brief Time when the submission was created (steady clock). */
+    std::chrono::steady_clock::time_point snap_time;
+    /** @brief Collected PV events to publish. One per PV for repeating op; buffered for back-time op. */
     std::vector<service::epics_impl::MonitorEventShrdPtr> snapshot_events;
-    SnapshotSubmissionType                                submission_type;
+    /** @brief Which parts of a submission are present (Header/Data/Tail). */
+    SnapshotSubmissionType submission_type;
+    /**
+     * @brief Iteration identifier assigned by the scheduler.
+     * @details Binds this submission to the logical snapshot iteration it belongs to.
+     *          - For batches containing Header, the scheduler assigns a new id and sets it here.
+     *          - For Data/Tail-only batches, the scheduler sets the id of the current iteration.
+     *          Consumers can rely on this value for coordination without reading shared state.
+     */
+    int64_t iteration_id{0};
 
-    // Constructor
-    SnapshotSubmission(const std::chrono::steady_clock::time_point& snap_time, std::vector<service::epics_impl::MonitorEventShrdPtr>&& snapshot_events, SnapshotSubmissionType submission_type)
-        : snap_time(snap_time), snapshot_events(std::move(snapshot_events)), submission_type(submission_type)
+    /**
+     * @brief Construct a submission with explicit iteration id.
+     * @param snap_time Time of submission creation.
+     * @param snapshot_events Collected events (moved in).
+     * @param submission_type Flags for header/data/tail presence.
+     * @param iteration_id Iteration id bound to this submission.
+     */
+    SnapshotSubmission(const std::chrono::steady_clock::time_point& snap_time, std::vector<service::epics_impl::MonitorEventShrdPtr>&& snapshot_events, SnapshotSubmissionType submission_type, int64_t iteration_id)
+        : snap_time(snap_time), snapshot_events(std::move(snapshot_events)), submission_type(submission_type), iteration_id(iteration_id)
     {
     }
 
-    // Move constructor
+    /**
+     * @brief Move-construct a submission.
+     * @param other Source to move from; left in valid but unspecified state.
+     */
     SnapshotSubmission(SnapshotSubmission&& other) noexcept
-        : snapshot_events(std::move(other.snapshot_events)), submission_type(other.submission_type)
+        : snapshot_events(std::move(other.snapshot_events)), submission_type(other.submission_type), iteration_id(other.iteration_id)
     {
     }
 
-    // Move assignment operator
+    /**
+     * @brief Move-assign a submission.
+     * @param other Source to move from.
+     * @return Reference to this.
+     */
     SnapshotSubmission& operator=(SnapshotSubmission&& other) noexcept
     {
         if (this != &other)
         {
             snapshot_events = std::move(other.snapshot_events);
             submission_type = other.submission_type;
+            iteration_id = other.iteration_id;
         }
         return *this;
     }
 
-    // Delete copy constructor and copy assignment to enforce move semantics
+    /** @brief Disable copy to enforce move-only semantics. */
     SnapshotSubmission(const SnapshotSubmission&) = delete;
+    /** @brief Disable copy to enforce move-only semantics. */
     SnapshotSubmission& operator=(const SnapshotSubmission&) = delete;
 };
 
 DEFINE_PTR_TYPES(SnapshotSubmission);
 
-/*
-@brief define the snapshot operation info
-@details This class is used to store the information and data about the snapshot operation
-it define an interface to add data and get data that will be implemented by the
-specific snapshot operation info class
-*/
+/**
+ * @brief Per-iteration synchronization primitives used by SnapshotOpInfo.
+ * @details One instance exists for each logical snapshot iteration (identified
+ *          by an iteration_id). It coordinates the ordering guarantees:
+ *          - Header-before-Data: Data publishers wait on `header_future` until
+ *            the Header publisher calls `set_value()` on `header_promise`.
+ *          - Data-before-Tail: Tail waits until all scheduled Data submissions
+ *            decrement `data_pending` to zero, signaled via `data_cv`.
+ *
+ *          Lifecycle:
+ *          - Created lazily on first use for a given iteration (beginHeaderGate
+ *            or dataScheduled).
+ *          - Cleared by SnapshotOpInfo after `waitDataDrained(iteration_id)` returns
+ *            to avoid unbounded growth.
+ *
+ *          Thread-safety:
+ *          - The struct itself is owned behind a shared_ptr. Access to the
+ *            map that holds these instances is guarded by SnapshotOpInfo's
+ *            `iteration_sync_mutex` when inserting/looking up instances.
+ *          - Within the struct, `data_mutex` protects `data_cv` wait/notify
+ *            operations. `data_pending` uses atomics to minimize contention.
+ *          - `header_promise/header_future` are set/consumed with map access
+ *            protected by `iteration_sync_mutex` to avoid races on replacement.
+ */
+struct IterationSyncState
+{
+    // Header gate
+    std::shared_ptr<std::promise<void>> header_promise;
+    std::shared_future<void>            header_future;
+    // Data drain
+    std::mutex              data_mutex;
+    std::condition_variable data_cv;
+    std::atomic<int>        data_pending{0};
+};
+
+/**
+ * @brief Base class for snapshot operations.
+ * @details Stores immutable command context and common state for repeating
+ *          or buffered snapshot implementations. Provides the interface to
+ *          accept EPICS events and produce submission batches. Also exposes
+ *          per-snapshot coordination primitives to guarantee publish order:
+ *          - Header gate: Data waits until Header is published per iteration.
+ *          - Data drain: Tail waits until all Data of the iteration is done.
+ *          Thread-safety: addData(), getData(), and the coordination helpers
+ *          are intended to be called from multiple threads.
+ */
 class SnapshotOpInfo : public WorkerAsyncOperation
 {
+    /** @brief Protect access to per-iteration synchronization map. */
+    std::mutex iteration_sync_mutex;
+    /** @brief Map of iteration_id to its synchronization state. */
+    std::unordered_map<int64_t, std::shared_ptr<IterationSyncState>> iteration_sync_states;
+
 protected:
-    // Filter PVStructure fields, returning only those in fields_to_include
+    /**
+     * @brief Filter PVStructure fields to a subset.
+     * @param src Source PVStructure; may be null.
+     * @param fields_to_include Fields to copy into the filtered structure.
+     * @return New PVStructure with only requested fields; null if src is null.
+     */
     const epics::pvData::PVStructure::const_shared_pointer filterPVField(const epics::pvData::PVStructure::const_shared_pointer& src, const std::unordered_set<std::string>& fields_to_include);
 
 public:
+    /**
+     * @brief Promise fulfilled when the snapshot is fully removed.
+     * @details Used by the manager to await clean teardown when stopping.
+     */
     std::promise<void> removal_promise;
-    // Pointer to the repeating snapshot command associated with this operation
+
+    /** @brief Command parameters associated with this operation (non-owning shared_ptr). */
     k2eg::controller::command::cmd::ConstRepeatingSnapshotCommandShrdPtr cmd;
 
-    // Index of the current snapshot iteration
-    std::atomic<int64_t> snapshot_iteration_index = 0;
 
-    // Name of the queue associated with this operation
+    /** @brief Normalized queue name where events are published. */
     const std::string queue_name;
 
-    // Indicates if the snapshot is triggered (immutable after construction)
+    /** @brief True if operation is trigger-driven instead of periodic. */
     const bool is_triggered;
 
-    // Flag to request a trigger for the snapshot operation
+    /** @brief Asynchronously request a trigger for the next window (triggered mode). */
     bool request_to_trigger = false;
 
-    // Indicates if the operation is currently running
+    /** @brief True while the snapshot operation is active; false when stopping. */
     bool is_running = true;
 
-    // Constructor: initializes with queue name and command pointer
+    /**
+     * @brief Construct a snapshot operation.
+     * @param queue_name Normalized queue name.
+     * @param cmd Repeating snapshot command parameters.
+     */
     SnapshotOpInfo(const std::string& queue_name, k2eg::controller::command::cmd::ConstRepeatingSnapshotCommandShrdPtr cmd);
 
-    // Destructor
+    /** @brief Destroy the snapshot operation. */
     virtual ~SnapshotOpInfo();
 
-    // Initialize operation with a list of sanitized PV names
+    /**
+     * @brief Initialize with sanitized PV list.
+     * @param sanitized_pv_name_list List of PV identifiers already sanitized.
+     * @return True on success; false if initialization fails.
+     */
     virtual bool init(std::vector<service::epics_impl::PVShrdPtr>& sanitized_pv_name_list) = 0;
 
-    // Add monitor event data to the operation
+    /**
+     * @brief Add a monitor event into the current window.
+     * @param event_data Event shared_ptr; ownership is not taken.
+     */
     virtual void addData(k2eg::service::epics_impl::MonitorEventShrdPtr event_data) = 0;
 
-    // Retrieve collected monitor event data
+    /**
+     * @brief Produce a submission batch from the current window.
+     * @return Submission object with header/data/tail flags and events.
+     */
     virtual SnapshotSubmissionShrdPtr getData() = 0;
 
-    // Check if the operation has timed out
+    /**
+     * @brief Check whether the current window expired.
+     * @param now Optional reference time; defaults to steady_clock::now().
+     * @return True if a submission should be produced.
+     */
     virtual bool isTimeout(const std::chrono::steady_clock::time_point& now = std::chrono::steady_clock::now()) override;
+
+    // Submission chaining removed: Tail now waits on per-iteration data drain.
+
+    /**
+     * @brief Begin a new header gate for a specific iteration.
+     * @details Creates (or resets) the IterationSyncState for `iteration_id` and
+     *          initializes its header promise/future. Call exactly once per iteration
+     *          when scheduling a submission that includes a Header, prior to any
+     *          Data scheduling for the same iteration.
+     * @param iteration_id Iteration identifier bound to this header gate.
+     */
+    void beginHeaderGate(int64_t iteration_id);
+
+    /**
+     * @brief Complete the header gate for a specific iteration.
+     * @details Signals the header promise inside IterationSyncState so any Data publishers
+     *          waiting on `waitForHeaderGate(iteration_id)` can proceed. Call right after
+     *          the Header message for `iteration_id` is published.
+     * @param iteration_id Iteration identifier whose header gate to release.
+     */
+    void completeHeaderGate(int64_t iteration_id);
+
+    /**
+     * @brief Wait until the Header for a specific iteration has been published.
+     * @details Looks up the IterationSyncState for `iteration_id` and blocks on its header
+     *          future. Use inside Data publishing path to guarantee Header-before-Data order.
+     *          If no state exists (should not happen when scheduled correctly), returns immediately.
+     * @param iteration_id Iteration identifier to wait on.
+     */
+    void waitForHeaderGate(int64_t iteration_id);
+
+    /**
+     * @brief Increment pending data submissions counter for a specific iteration.
+     * @details Lazily creates IterationSyncState if missing and increments `data_pending`.
+     *          Call exactly once per scheduled Data submission batch for `iteration_id`,
+     *          before the associated task begins publishing.
+     * @param iteration_id Iteration identifier whose counter to increment.
+     */
+    void dataScheduled(int64_t iteration_id);
+
+    /**
+     * @brief Decrement pending data submissions counter and notify waiters for a specific iteration.
+     * @details Decrements `data_pending` and, when it reaches zero, notifies `data_cv` inside the
+     *          IterationSyncState. Call at the end of the Data publishing task for `iteration_id`.
+     * @param iteration_id Iteration identifier whose counter to decrement.
+     */
+    void dataCompleted(int64_t iteration_id);
+
+    /**
+     * @brief Block until all scheduled data submissions are completed for a specific iteration.
+     * @details Waits on the `data_cv` of IterationSyncState for `iteration_id` until `data_pending`
+     *          is zero, ensuring Tail publishes after all Data. After the wait completes, the
+     *          per-iteration state is cleaned up to avoid leaks.
+     * @param iteration_id Iteration identifier to wait on.
+     */
+    void waitDataDrained(int64_t iteration_id);
 };
 DEFINE_PTR_TYPES(SnapshotOpInfo)
 } // namespace k2eg::controller::node::worker::snapshot

--- a/src/k2eg/controller/node/worker/snapshot/SnapshotRepeatingOpInfo.cpp
+++ b/src/k2eg/controller/node/worker/snapshot/SnapshotRepeatingOpInfo.cpp
@@ -62,6 +62,7 @@ SnapshotSubmissionShrdPtr SnapshotRepeatingOpInfo::getData()
     return MakeSnapshotSubmissionShrdPtr(
         std::chrono::steady_clock::now(),
         std::move(result),
-        (SnapshotSubmissionType::Header | SnapshotSubmissionType::Data | SnapshotSubmissionType::Tail)
+        (SnapshotSubmissionType::Header | SnapshotSubmissionType::Data | SnapshotSubmissionType::Tail),
+        0 // scheduler assigns iteration id
     );
 }


### PR DESCRIPTION
- Add iteration_id to SnapshotSubmission and propagate via scheduler/task.
- ContinuousSnapshotManager: resolve iteration on Header; track active_iteration_id_ per snapshot; attach iteration_id to every submission; count Data batches with dataScheduled(); clean up active mapping on loop continuation.
- SnapshotOpInfo: introduce per-iteration sync (header gate + data drain) using promise/future and condition_variable; add beginHeaderGate(), completeHeaderGate(), waitForHeaderGate(), dataScheduled(), dataCompleted(), waitDataDrained(); remove shared atomic iteration index usage.
- SnapshotSubmissionTask: use submission_shrd_ptr->iteration_id; error/log if missing; release header gate after publish; wait for header before Data; wait for data drain before Tail.
- BackTimedBufferedSnapshotOpInfo and SnapshotRepeatingOpInfo: construct submissions with iteration_id=0 (scheduler assigns).
- Minor comments and docs for clarity; update IterationState with data_pending.

Rationale: ensures deterministic per-iteration ordering under concurrency, preventing Data/Tail from racing ahead of Header and guaranteeing Tail only after all Data publishes.