### PR TITLE
EPICS monitoring: add per-PV throttling/metrics; refactor draining & lifecycle

### DIFF
--- a/src/k2eg/service/epics/EpicsServiceManager.h
+++ b/src/k2eg/service/epics/EpicsServiceManager.h
@@ -46,6 +46,14 @@ struct EpicsServiceManagerConfig
     // the maximum number of events to fetch from the monitor queue
     // this is used to limit the number of events to process
     std::int32_t max_event_from_monitor_queue = 100;
+
+    // Per-PV throttling configuration (microseconds)
+    std::int32_t pv_min_throttle_us = 50;    // minimal backoff for idle PVs
+    std::int32_t pv_max_throttle_us = 50000; // cap backoff to 50ms
+    std::int32_t pv_idle_threshold = 10;     // idle cycles before increasing backoff
+
+    // Disable per-thread throttling updates/metrics, prefer per-PV
+    bool disable_thread_throttle = true;
 };
 
 // describe a channel ellement in map per each PV
@@ -59,6 +67,8 @@ struct ChannelMapElement
     int keep_alive;
     // Indicates if the channel is currently active
     bool active = false;
+    // Per-PV throttling manager (shared to allow safe use outside locks)
+    std::shared_ptr<k2eg::common::ThrottlingManager> pv_throttle = std::make_shared<k2eg::common::ThrottlingManager>();
 };
 DEFINE_PTR_TYPES(ChannelMapElement)
 typedef std::unique_lock<std::shared_mutex> WriteLockCM;

--- a/src/k2eg/service/metric/IEpicsMetric.h
+++ b/src/k2eg/service/metric/IEpicsMetric.h
@@ -6,7 +6,23 @@
 namespace k2eg::service::metric {
 
 // epics counter types
-enum class IEpicsMetricCounterType { Get, Put, MonitorTimeout, MonitorData, MonitorFail, MonitorCancel, MonitorDisconnect, TotalMonitorGauge, ActiveMonitorGauge, ThrottlingIdleGauge, ThrottlingEventCounter, ThrottlingDurationGauge, ThrottleGauge};
+enum class IEpicsMetricCounterType {
+  Get,
+  Put,
+  MonitorTimeout,
+  MonitorData,
+  MonitorFail,
+  MonitorCancel,
+  MonitorDisconnect,
+  TotalMonitorGauge,
+  ActiveMonitorGauge,
+  ThrottlingIdleGauge,
+  ThrottlingEventCounter,
+  ThrottlingDurationGauge,
+  ThrottleGauge,
+  PVThrottleGauge,   // per-PV throttle in microseconds
+  PVBacklogGauge     // per-PV backlog indicator (0/1)
+};
 
 // Epics metric group
 class IEpicsMetric {

--- a/src/k2eg/service/metric/impl/prometheus/PrometheusEpicsMetric.cpp
+++ b/src/k2eg/service/metric/impl/prometheus/PrometheusEpicsMetric.cpp
@@ -30,6 +30,8 @@ PrometheusEpicsMetric::PrometheusEpicsMetric()
                                   .Help("Total poll time in microseconds per thread to wait for events")
                                   .Register(*registry))
     , throttle_gauge_family(BuildGauge().Name("k2eg_epics_thread_throttle_ms").Help("Current throttle delay per thread in ms").Register(*registry))
+    , pv_throttle_gauge_family(BuildGauge().Name("k2eg_epics_pv_throttle_us").Help("Current throttle delay per PV in microseconds").Register(*registry))
+    , pv_backlog_gauge_family(BuildGauge().Name("k2eg_epics_pv_backlog_flag").Help("Backlog flag (1 if backlog detected during last poll)").Register(*registry))
     , get_ok_counter(ioc_read_write.Add({{"op", "get"}}))
     , put_ok_counter(ioc_read_write.Add({{"op", "put"}}))
     , monitor_event_data(ioc_read_write.Add({{"op", "monitor"}, {"evt_type", "data"}}))
@@ -90,5 +92,7 @@ void PrometheusEpicsMetric::incrementCounter(IEpicsMetricCounterType type, const
     case IEpicsMetricCounterType::ThrottlingEventCounter: event_counter_family.Add(label).Increment(inc_value); break;
     case IEpicsMetricCounterType::ThrottlingDurationGauge: duration_gauge_family.Add(label).Set(inc_value); break;
     case IEpicsMetricCounterType::ThrottleGauge: throttle_gauge_family.Add(label).Set(inc_value); break;
+    case IEpicsMetricCounterType::PVThrottleGauge: pv_throttle_gauge_family.Add(label).Set(inc_value); break;
+    case IEpicsMetricCounterType::PVBacklogGauge: pv_backlog_gauge_family.Add(label).Set(inc_value); break;
     }
 }

--- a/src/k2eg/service/metric/impl/prometheus/PrometheusEpicsMetric.h
+++ b/src/k2eg/service/metric/impl/prometheus/PrometheusEpicsMetric.h
@@ -29,6 +29,8 @@ class PrometheusEpicsMetric : public IEpicsMetric
     prometheus::Family<prometheus::Counter>& event_counter_family;
     prometheus::Family<prometheus::Gauge>&   idle_gauge_family;
     prometheus::Family<prometheus::Gauge>&   throttle_gauge_family;
+    prometheus::Family<prometheus::Gauge>&   pv_throttle_gauge_family;
+    prometheus::Family<prometheus::Gauge>&   pv_backlog_gauge_family;
     prometheus::Counter&                     get_ok_counter;
     prometheus::Counter&                     put_ok_counter;
     prometheus::Counter&                     monitor_event_data;


### PR DESCRIPTION
Introduce per-PV throttling and visibility into backlog; shift monitor draining to poll() and tighten lifecycle handling.

Core changes:
- EpicsMonitorOperation: bound poll loop by requested elements; move data draining from monitorEvent() to poll() to cap work per cycle; clean up comments and ensure newline at EOF.
- EpicsServiceManager(.h/.cpp):
  - Add per-PV throttling via ThrottlingManager in ChannelMapElement (pv_throttle) and track active flag.
  - Initialize pv_throttle and active for addChannel/getMonitorOp/getChannelData using new config knobs (pv_min_throttle_us, pv_max_throttle_us, pv_idle_threshold).
  - Refactor task loop: compute activity, update channel state, handle keep_alive==0 deletion, and poll monitor with bounded fetch; minor naming cleanups (local_to_force/should_delete).
- EpicsServiceManagerConfig: add pv_min_throttle_us, pv_max_throttle_us, pv_idle_threshold and disable_thread_throttle flag (default true).
- Metrics (IEpicsMetric/Prometheus):
  - Add PVThrottleGauge and PVBacklogGauge counters; expose as Prometheus gauges (k2eg_epics_pv_throttle_us, k2eg_epics_pv_backlog_flag).
  - Wire increment handling for the new metric types.

Rationale:
- Per-PV throttling avoids over/under-backoff tied to worker threads and improves fairness.
- Moving drain to poll() bounds work per event, reducing latency spikes on busy PVs.
- New metrics provide visibility into throttling behavior and backlogs for observability.

Notes:
- Default throttle params: min=50us, max=50ms, idle_threshold=10 cycles; can be tuned via config.
- Retains existing per-thread metric but allows disabling in favor of per-PV.
