### PR TITLE
EPICS monitor: drain a bounded number in callback to prevent drops at…

### DIFF
--- a/src/k2eg/service/epics/EpicsMonitorOperation.cpp
+++ b/src/k2eg/service/epics/EpicsMonitorOperation.cpp
@@ -125,7 +125,22 @@ void MonitorOperationImpl::monitorEvent(const pvac::MonitorEvent& evt)
         received_event->event_disconnect->push_back(std::make_shared<MonitorEvent>(MonitorEvent{EventType::Disconnec, pv_name, evt.message, nullptr}));
         break;
     case pvac::MonitorEvent::Data:
-        // Defer draining to poll() to bound work per cycle.
+        // Quickly drain a bounded number of items here to avoid
+        // dropping/coalescing events under high-rate PVs. Remaining
+        // backlog (if any) is drained in poll().
+        {
+            int drained = 0;
+            constexpr int kMaxDrainPerCallback = 128;
+            while (!mon.complete() && drained < kMaxDrainPerCallback)
+            {
+                if (!mon.poll())
+                    break;
+                ++drained;
+                auto tmp_data = std::make_shared<epics::pvData::PVStructure>(mon.root->getStructure());
+                tmp_data->copy(*mon.root);
+                received_event->event_data->push_back(std::make_shared<MonitorEvent>(MonitorEvent{EventType::Data, "", {pv_name, tmp_data}}));
+            }
+        }
         break;
     }
 }


### PR DESCRIPTION
… high rates

Drain up to 128 items in MonitorOperationImpl::monitorEvent(Data) to keep up with high-frequency PVs (e.g., 120 Hz) and reduce coalescing/drops; remaining backlog still drained in poll().