### PR TITLE
Improve/epics service manager (#148)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,3 +100,73 @@ jobs:
         artifact_name: ${{ needs.build_ubuntu.outputs.artifact_name }}
         docker_compose_profile: app-ubuntu
       secrets: inherit
+    build_pr_docker_image:
+      name: Build PR Docker Image
+      needs: check-changed-file
+      if: needs.check-changed-file.outputs.source_changed == 'true'
+      runs-on: ubuntu-latest
+      env:
+        GITVERSION_VERSION: 5.12.0
+        REGISTRY: ghcr.io
+        IMAGE_NAME: ${{ github.repository }}
+      strategy:
+        fail-fast: false
+        matrix:
+          include:
+            - dockerfile: Dockerfile.ubuntu
+              variant: ubuntu
+      steps:
+        - name: Check out repository code
+          uses: actions/checkout@v3
+          with:
+            fetch-depth: 0
+        - name: Install GitVersion
+          run: |
+            set -euo pipefail
+            pushd /tmp
+            wget https://github.com/GitTools/GitVersion/releases/download/$GITVERSION_VERSION/gitversion-linux-x64-$GITVERSION_VERSION.tar.gz
+            tar zxvf gitversion-linux-x64-$GITVERSION_VERSION.tar.gz
+            echo "/tmp" >> "$GITHUB_PATH"
+            popd
+        - name: Determine PR version
+          id: gitversion
+          run: |
+            set -euo pipefail
+            VERSION_JSON=$(gitversion /output json)
+            echo "$VERSION_JSON"
+            PR_VERSION=$(echo "$VERSION_JSON" | jq -r '.SemVer')
+            echo "pr_version=$PR_VERSION" >> "$GITHUB_OUTPUT"
+            echo "PR_VERSION=$PR_VERSION" >> "$GITHUB_ENV"
+        - name: Manage version header
+          run: |
+            tools/manage-version.sh src/k2eg/version.h
+            cat src/k2eg/version.h
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v2
+        - name: Log in to the Container registry
+          uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+          with:
+            registry: ${{ env.REGISTRY }}
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+        - name: Docker meta
+          id: meta
+          uses: docker/metadata-action@v4
+          with:
+            images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.variant }}
+            tags: |
+              type=raw,value=${{ env.PR_VERSION }}
+              type=raw,value=pr-${{ github.event.pull_request.number }}
+            labels: |
+              maintainer=bisegni@slac.stanford.edu
+              org.opencontainers.image.title=K2EG
+              org.opencontainers.image.description=Kafka To Epics Gateway
+              org.opencontainers.image.vendor=SLAC National Accelerator Laboratory
+        - name: Build and push Docker image
+          uses: docker/build-push-action@v4
+          with:
+            context: .
+            file: ${{ matrix.dockerfile }}
+            push: true
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ kafka-consumer.kafka
 kafka-producer.kafka
 *.log
 src/k2eg/config.h
+debug.conf

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,9 +32,9 @@
                 // "--pub-impl-kv=queue.buffering.max.ms:1",
                 "--sub-impl-kv=session.timeout.ms:6000",
                 "--sub-impl-kv=max.poll.interval.ms:10000",
-                "--snapshot-repeating-scheduler-thread=16"
+                "--snapshot-repeating-scheduler-thread=8"
             ],
-            "stopAtEntry": false,
+            "stopAtEntry": true,
             "cwd": "${workspaceFolder}",
             "envFile": "${workspaceFolder}/.vscode/.env",
             "environment": [

--- a/src/k2eg/common/ThrottlingManager.h
+++ b/src/k2eg/common/ThrottlingManager.h
@@ -49,8 +49,12 @@ public:
         : stats{0, 0, 0, min_throttle_us} {}
 
     ThrottlingManager(int min_us, int max_us, int threshold) noexcept
-        : stats{0, 0, 0, min_us}, min_throttle_us_(min_us), max_throttle_us_(max_us), idle_threshold_(threshold) {}
+        : stats{0, 0, 0, min_us}
+        , min_throttle_us_(min_us)
+        , max_throttle_us_(max_us)
+        , idle_threshold_(threshold) {}
 
+    // Boolean-based API: back off when idle, reset when events
     void update(bool had_events)
     {
         if (!had_events)

--- a/src/k2eg/controller/node/worker/MonitorCommandWorker.cpp
+++ b/src/k2eg/controller/node/worker/MonitorCommandWorker.cpp
@@ -333,6 +333,9 @@ void MonitorCommandWorker::epicsMonitorEvent(EpicsServiceManagerHandlerParamterT
     // check fail to connect pv
     {
         std::shared_lock slock(channel_map_mtx);
+        if(channel_topics_map.size() == 0) {
+            return;
+        }   
         for (auto& event : *event_received->event_fail)
         {
             auto it = channel_topics_map.find(event->channel_data.pv_name);
@@ -378,7 +381,6 @@ void MonitorCommandWorker::epicsMonitorEvent(EpicsServiceManagerHandlerParamterT
                  {"k2eg-ser-type", serialization_to_string(static_cast<SerializationType>(monitor_info.event_serialization))}});
         }
     }
-    publisher->flush(100);
 }
 
 #pragma endregion MonitorMessage

--- a/src/k2eg/controller/node/worker/snapshot/ContinuousSnapshotManager.cpp
+++ b/src/k2eg/controller/node/worker/snapshot/ContinuousSnapshotManager.cpp
@@ -73,13 +73,13 @@ inline uint64_t take_events_for_iteration(const std::string& snapshot_name, int6
 }
 } // namespace
 
-void set_snapshot_thread_name(const std::size_t idx)
+void set_snapshot_thread_name(const char* name, const std::size_t idx)
 {
     // Use a local variable, not static/global
     std::ostringstream oss;
-    oss << "Repeating Snapshot " << idx;
-    const std::string name = oss.str();
-    BS::this_thread::set_os_thread_name(name);
+    oss << name << idx;
+    const std::string name_ = oss.str();
+    BS::this_thread::set_os_thread_name(name_);
 }
 
 std::string get_pv_names(std::set<std::string> name_set)
@@ -96,9 +96,14 @@ std::string get_pv_names(std::set<std::string> name_set)
     return all_pv_names;
 }
 
-inline auto thread_namer = [](unsigned long idx)
+inline auto thread_namer_submission = [](unsigned long idx)
 {
-    set_snapshot_thread_name(idx);
+    set_snapshot_thread_name("Repeating Snapshot Submitting", idx);
+};
+
+inline auto thread_namer_daq_processing = [](unsigned long idx)
+{
+    set_snapshot_thread_name("Repeating Snapshot DAQ Processing", idx);
 };
 
 ContinuousSnapshotManager::ContinuousSnapshotManager(const RepeatingSnapshotConfiguration& repeating_snapshot_configuration, k2eg::service::epics_impl::EpicsServiceManagerShrdPtr epics_service_manager)
@@ -106,7 +111,8 @@ ContinuousSnapshotManager::ContinuousSnapshotManager(const RepeatingSnapshotConf
     , logger(ServiceResolver<ILogger>::resolve())
     , publisher(ServiceResolver<IPublisher>::resolve())
     , epics_service_manager(epics_service_manager)
-    , thread_pool(std::make_shared<BS::light_thread_pool>(repeating_snapshot_configuration.snapshot_processing_thread_count, thread_namer))
+    , thread_pool_submitting(std::make_shared<BS::light_thread_pool>(repeating_snapshot_configuration.snapshot_processing_thread_count, thread_namer_submission))
+    , thread_pool_daq_processing(std::make_shared<BS::light_thread_pool>(1, thread_namer_daq_processing))
     , metrics(ServiceResolver<IMetricService>::resolve()->getNodeControllerMetric())
     , iteration_sync_(std::make_unique<SnapshotIterationSynchronizer>())
 {
@@ -136,7 +142,8 @@ ContinuousSnapshotManager::~ContinuousSnapshotManager()
     // remove epics monitor handler
     epics_handler_token.reset();
     // stop all the thread
-    thread_pool->wait();
+    thread_pool_daq_processing->wait();
+    thread_pool_submitting->wait();
     logger->logMessage("[ContinuousSnapshotManager] Continuous snapshot manager stopped");
 }
 
@@ -399,37 +406,29 @@ void ContinuousSnapshotManager::stopSnapshot(command::cmd::ConstRepeatingSnapsho
 
 void ContinuousSnapshotManager::epicsMonitorEvent(EpicsServiceManagerHandlerParamterType event_received)
 {
-    // prepare reading lock
-    std::shared_lock read_lock(snapshot_running_mutex_);
-
-    // for (auto& event : *event_received->event_fail)
-    // {
-    //     // set the channel as not active
-    //     auto it = snapshot_runinnig_.find(event->channel_data.pv_name);
-    //     if (it != snapshot_runinnig_.end())
-    //     {
-    //         it->second->addData(nullptr, std::memory_order_release);
-    //     }
-    // }
-
-    // manage the received data
-    std::set<std::string> pv_names;
-    for (auto& event : *event_received->event_data)
-    {
-        const std::string pv_name = event->channel_data.pv_name;
-        pv_names.insert(pv_name);
-        // store event on the global cache using the atomic pointer
-        auto range = pv_snapshot_map_.equal_range(pv_name);
-        for (auto it = range.first; it != range.second; ++it)
+    // process the received event in a separate thread to not block the epics thread
+    thread_pool_daq_processing->detach_task(
+        [this, event_received]() mutable
         {
-            if (it->second)
+            // prepare reading lock
+            std::shared_lock read_lock(snapshot_running_mutex_);
+            // manage the received data
+            std::set<std::string> pv_names;
+            for (auto& event : *event_received->event_data)
             {
-                it->second->addData(event);
+                const std::string pv_name = event->channel_data.pv_name;
+                pv_names.insert(pv_name);
+                // store event on the global cache using the atomic pointer
+                auto range = pv_snapshot_map_.equal_range(pv_name);
+                for (auto it = range.first; it != range.second; ++it)
+                {
+                    if (it->second)
+                    {
+                        it->second->addData(event);
+                    }
+                }
             }
-        }
-    }
-    // logger->logMessage(STRING_FORMAT("EPICS forwarded %1% data events for PVs: %2%",
-    // event_received->event_data->size() % get_pv_names(pv_names)), LogLevel::DEBUG);
+        });
 }
 
 void ContinuousSnapshotManager::expirationCheckerLoop()
@@ -458,7 +457,8 @@ void ContinuousSnapshotManager::expirationCheckerLoop()
                     bool        to_continue = false;
                     bool        last_submission = false;
 
-                    for (const auto& pv_name : non_updated_pvs) {
+                    for (const auto& pv_name : non_updated_pvs)
+                    {
                         // Forward the last data for each non-updated PV
                         epics_service_manager->forceMonitorChannelUpdate(pv_name, false);
                     }
@@ -521,7 +521,7 @@ void ContinuousSnapshotManager::expirationCheckerLoop()
                     {
                         s_op_ptr->dataScheduled(scheduled_iteration_id);
                     }
-                    thread_pool->detach_task(
+                    thread_pool_submitting->detach_task(
                         [this, s_op_ptr, submission_shard_ptr, last_submission]() mutable
                         {
                             SnapshotSubmissionTask task(s_op_ptr, submission_shard_ptr, this->publisher, this->logger, *this->iteration_sync_, last_submission);

--- a/src/k2eg/controller/node/worker/snapshot/ContinuousSnapshotManager.h
+++ b/src/k2eg/controller/node/worker/snapshot/ContinuousSnapshotManager.h
@@ -166,7 +166,10 @@ class ContinuousSnapshotManager
     PVSnapshotMap pv_snapshot_map_;
 
     // Thread pool for processing snapshot operations
-    std::shared_ptr<BS::light_thread_pool> thread_pool;
+    std::shared_ptr<BS::light_thread_pool> thread_pool_submitting;
+
+    // Thread pool for DAQ processing (if needed)
+    std::shared_ptr<BS::light_thread_pool> thread_pool_daq_processing;
 
     // Shared pointer to the EPICS service manager
     k2eg::service::epics_impl::EpicsServiceManagerShrdPtr epics_service_manager;

--- a/src/k2eg/service/epics/EpicsMonitorOperation.cpp
+++ b/src/k2eg/service/epics/EpicsMonitorOperation.cpp
@@ -1,5 +1,5 @@
-#include "k2eg/service/epics/PVStructureMerger.h"
-#include <iostream>
+#include <k2eg/service/epics/PVStructureMerger.h>
+
 #include <k2eg/service/epics/EpicsData.h>
 #include <k2eg/service/epics/EpicsGetOperation.h>
 #include <k2eg/service/epics/EpicsMonitorOperation.h>
@@ -79,12 +79,6 @@ size_t MonitorOperationImpl::poll(size_t element_to_fetch) const
             force_update = false;
         }
     }
-    else
-    {
-        // destroy the get operation
-        if (get_op)
-            get_op.reset();
-    }
     fetched = received_event->event_data->size() + received_event->event_cancel->size() +
               received_event->event_disconnect->size() + received_event->event_fail->size() +
               received_event->event_timeout->size();
@@ -125,22 +119,8 @@ void MonitorOperationImpl::monitorEvent(const pvac::MonitorEvent& evt)
         received_event->event_disconnect->push_back(std::make_shared<MonitorEvent>(MonitorEvent{EventType::Disconnec, pv_name, evt.message, nullptr}));
         break;
     case pvac::MonitorEvent::Data:
-        // Quickly drain a bounded number of items here to avoid
-        // dropping/coalescing events under high-rate PVs. Remaining
-        // backlog (if any) is drained in poll().
-        {
-            int drained = 0;
-            constexpr int kMaxDrainPerCallback = 128;
-            while (!mon.complete() && drained < kMaxDrainPerCallback)
-            {
-                if (!mon.poll())
-                    break;
-                ++drained;
-                auto tmp_data = std::make_shared<epics::pvData::PVStructure>(mon.root->getStructure());
-                tmp_data->copy(*mon.root);
-                received_event->event_data->push_back(std::make_shared<MonitorEvent>(MonitorEvent{EventType::Data, "", {pv_name, tmp_data}}));
-            }
-        }
+        // to not overload the event queue, we do nothing here
+        // data will be fetched in poll()
         break;
     }
 }
@@ -221,11 +201,13 @@ EventReceivedShrdPtr CombinedMonitorOperation::getEventData() const
 
 bool CombinedMonitorOperation::hasData() const
 {
+    std::lock_guard<std::mutex> lock(evt_mtx);
     return monitor_principal_request->hasData() && (monitor_additional_request->hasData() || last_additional_evt_received);
 }
 
 bool CombinedMonitorOperation::hasEvents() const
 {
+    std::lock_guard<std::mutex> lock(evt_mtx);
     return monitor_principal_request->hasEvents() && (monitor_additional_request->hasData() || last_additional_evt_received);
 }
 

--- a/src/k2eg/service/metric/IEpicsMetric.h
+++ b/src/k2eg/service/metric/IEpicsMetric.h
@@ -21,7 +21,8 @@ enum class IEpicsMetricCounterType {
   ThrottlingDurationGauge,
   ThrottleGauge,
   PVThrottleGauge,   // per-PV throttle in microseconds
-  PVBacklogGauge     // per-PV backlog indicator (0/1)
+  PVBacklogCounter,  // per-PV total items drained (counter)
+  PVProcessingDurationGauge // mean processing duration per PV in microseconds
 };
 
 // Epics metric group

--- a/src/k2eg/service/metric/impl/prometheus/PrometheusEpicsMetric.cpp
+++ b/src/k2eg/service/metric/impl/prometheus/PrometheusEpicsMetric.cpp
@@ -31,7 +31,8 @@ PrometheusEpicsMetric::PrometheusEpicsMetric()
                                   .Register(*registry))
     , throttle_gauge_family(BuildGauge().Name("k2eg_epics_thread_throttle_ms").Help("Current throttle delay per thread in ms").Register(*registry))
     , pv_throttle_gauge_family(BuildGauge().Name("k2eg_epics_pv_throttle_us").Help("Current throttle delay per PV in microseconds").Register(*registry))
-    , pv_backlog_gauge_family(BuildGauge().Name("k2eg_epics_pv_backlog_gauge").Help("Backlog gauge (number of items in backlog)").Register(*registry))
+    , pv_backlog_counter_family(BuildCounter().Name("k2eg_epics_pv_backlog_total").Help("Total number of items drained per PV").Register(*registry))
+    , pv_processing_duration_gauge_family(BuildGauge().Name("k2eg_epics_pv_processing_duration_us").Help("Mean processing duration per PV in microseconds").Register(*registry))
     , get_ok_counter(ioc_read_write.Add({{"op", "get"}}))
     , put_ok_counter(ioc_read_write.Add({{"op", "put"}}))
     , monitor_event_data(ioc_read_write.Add({{"op", "monitor"}, {"evt_type", "data"}}))
@@ -93,6 +94,7 @@ void PrometheusEpicsMetric::incrementCounter(IEpicsMetricCounterType type, const
     case IEpicsMetricCounterType::ThrottlingDurationGauge: duration_gauge_family.Add(label).Set(inc_value); break;
     case IEpicsMetricCounterType::ThrottleGauge: throttle_gauge_family.Add(label).Set(inc_value); break;
     case IEpicsMetricCounterType::PVThrottleGauge: pv_throttle_gauge_family.Add(label).Set(inc_value); break;
-    case IEpicsMetricCounterType::PVBacklogGauge: pv_backlog_gauge_family.Add(label).Set(inc_value); break;
+    case IEpicsMetricCounterType::PVBacklogCounter: pv_backlog_counter_family.Add(label).Increment(inc_value); break;
+    case IEpicsMetricCounterType::PVProcessingDurationGauge: pv_processing_duration_gauge_family.Add(label).Set(inc_value); break;
     }
 }

--- a/src/k2eg/service/metric/impl/prometheus/PrometheusEpicsMetric.h
+++ b/src/k2eg/service/metric/impl/prometheus/PrometheusEpicsMetric.h
@@ -30,7 +30,8 @@ class PrometheusEpicsMetric : public IEpicsMetric
     prometheus::Family<prometheus::Gauge>&   idle_gauge_family;
     prometheus::Family<prometheus::Gauge>&   throttle_gauge_family;
     prometheus::Family<prometheus::Gauge>&   pv_throttle_gauge_family;
-    prometheus::Family<prometheus::Gauge>&   pv_backlog_gauge_family;
+    prometheus::Family<prometheus::Counter>& pv_backlog_counter_family;
+    prometheus::Family<prometheus::Gauge>&   pv_processing_duration_gauge_family;
     prometheus::Counter&                     get_ok_counter;
     prometheus::Counter&                     put_ok_counter;
     prometheus::Counter&                     monitor_event_data;

--- a/tools/fetch_metric.py
+++ b/tools/fetch_metric.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Fetch and print a Prometheus metric exposed over HTTP."""
+
+import argparse
+import re
+import sys
+import urllib.error
+import urllib.request
+from typing import Dict, Iterable, Optional, Tuple
+
+
+METRIC_LINE_RE = re.compile(
+    r"^(?P<name>[a-zA-Z_:][a-zA-Z0-9_:]*)"
+    r"(?:\{(?P<labels>[^}]*)\})?\s+"
+    r"(?P<value>[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?)"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Download Prometheus metrics and print the value for a specific metric."
+    )
+    parser.add_argument(
+        "--url",
+        default="http://localhost:8080/metrics",
+        help="Metrics endpoint to query (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--metric",
+        help="Metric name to print (e.g. k2eg_epics_pv_processing_duration_us). If omitted, print all metrics.",
+    )
+    parser.add_argument(
+        "--label",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Optional label filter; repeat for multiple labels",
+    )
+    return parser.parse_args()
+
+
+def parse_label_filters(raw_labels: Iterable[str]) -> Dict[str, str]:
+    filters: Dict[str, str] = {}
+    for raw in raw_labels:
+        if "=" not in raw:
+            raise ValueError(f"Invalid label filter '{raw}'. Expected KEY=VALUE format.")
+        key, value = raw.split("=", 1)
+        filters[key.strip()] = value.strip()
+    return filters
+
+
+def parse_labels_block(block: str) -> Dict[str, str]:
+    labels: Dict[str, str] = {}
+    if not block:
+        return labels
+    for item in block.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        if "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        if len(value) >= 2 and value[0] == value[-1] == '"':
+            value = value[1:-1]
+        labels[key] = value
+    return labels
+
+
+def load_metrics(url: str) -> str:
+    try:
+        with urllib.request.urlopen(url) as response:
+            return response.read().decode("utf-8", errors="replace")
+    except urllib.error.URLError as exc:  # pragma: no cover - defensive guard
+        raise SystemExit(f"Failed to fetch metrics from {url}: {exc}")
+
+
+def find_metric(
+    metrics_body: str, metric_name: Optional[str], label_filters: Dict[str, str]
+) -> Iterable[Tuple[str, Dict[str, str], str]]:
+    for line in metrics_body.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        match = METRIC_LINE_RE.match(line)
+        if not match:
+            continue
+        name = match.group("name")
+        if metric_name and name != metric_name:
+            continue
+        labels = parse_labels_block(match.group("labels"))
+        if all(labels.get(k) == v for k, v in label_filters.items()):
+            yield name, labels, match.group("value")
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        label_filters = parse_label_filters(args.label)
+    except ValueError as exc:
+        raise SystemExit(str(exc))
+
+    metrics_text = load_metrics(args.url)
+    matches = list(find_metric(metrics_text, args.metric, label_filters))
+
+    if not matches:
+        wanted = ", ".join(f"{k}={v}" for k, v in label_filters.items())
+        label_msg = f" with labels [{wanted}]" if wanted else ""
+        metric_msg = f" '{args.metric}'" if args.metric else ""
+        raise SystemExit(f"Metric{metric_msg}{label_msg} not found at {args.url}")
+
+    for name, labels, value in matches:
+        label_str = ", ".join(f"{k}={v}" for k, v in sorted(labels.items()))
+        if label_str:
+            print(f"{name}{{{label_str}}} {value}")
+        else:
+            print(f"{name} {value}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:  # pragma: no cover - graceful exit
+        sys.exit(130)

--- a/tools/fetch_metric.sh
+++ b/tools/fetch_metric.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Usage: ./collect_metrics.sh METRIC_NAME OUTPUT_FILE
+METRIC="$1"
+OUTPUT_FILE="$2"
+
+if [ -z "$METRIC" ] || [ -z "$OUTPUT_FILE" ]; then
+    echo "Usage: $0 METRIC_NAME OUTPUT_FILE"
+    exit 1
+fi
+
+while true; do
+    echo "### $(date '+%Y-%m-%d %H:%M:%S') ###" >> "$OUTPUT_FILE"
+    python tools/fetch_metric.py --metric "$METRIC" >> "$OUTPUT_FILE"
+    echo "" >> "$OUTPUT_FILE"
+    sleep 1
+done


### PR DESCRIPTION
feat(epics): Improve PV scheduling and add PV backlog counter

  - Use exponential backoff on idle; reset throttle on activity
  - Convert per-PV backlog gauge to Prometheus counter (k2eg_epics_pv_backlog_total)
  - Accumulate drained items via single atomic; flush deltas in stats loop and on cleanup
  - Remove backlog gauge emissions; keep throttle and processing duration gauges
  - Harden EpicsServiceManager task flow and cleanup paths
  - Add metric fetch scripts and minor CI/editor config updates