### PR TITLE
fix(snapshot): preserve pending PVs after timeout

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -69,29 +69,22 @@ services:
           tail -f /dev/null
     volumes:
       - ../test:/app
-  zookeeper:
-    platform: linux/amd64
-    image: bitnami/zookeeper:3.8.1
-    # ports:
-    #   - 2181:2181
-    environment:
-      - ALLOW_ANONYMOUS_LOGIN=yes
-
   kafka:
-    platform: linux/amd64
-    image: bitnami/kafka:3.4.0
-    # ports:
-    #   - 9092:9092
-    #   - 9093:9093
+    # platform: linux/amd64
+    image: apache/kafka:4.1.0
     environment:
-      - KAFKA_BROKER_ID=1
-      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
-      - ALLOW_PLAINTEXT_LISTENER=yes
-      - KAFKA_ENABLE_KRAFT=no
-      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
-      - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9093
-      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka:9092,EXTERNAL://localhost:9093
-      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=CLIENT
-      - KAFKA_CFG_MESSAGE_MAX_BYTES=256000
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_NUM_PARTITIONS: 1
+      
 volumes:
   consul_data: {}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,34 +26,22 @@ services:
     volumes:
       - consul_data:/consul/data  # Optional persistent storage for Consul data
 
-  zookeeper:
-    image: bitnami/zookeeper:3.8.1
-    environment:
-      - ALLOW_ANONYMOUS_LOGIN=yes
-    logging:
-      driver: none
-
   kafka:
-    image: bitnami/kafka:3.4.0
-    ports:
-      - 9092:9092
-      - 9093:9093
+    # platform: linux/amd64
+    image: apache/kafka:4.1.0
     environment:
-      - BITNAMI_DEBUG=yes
-      - KAFKA_BROKER_ID=1
-      - KAFKA_ENABLE_KRAFT=no
-      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
-      - ALLOW_PLAINTEXT_LISTENER=yes
-      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
-      - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9093
-      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka:9092,EXTERNAL://localhost:9093
-      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=CLIENT
-    volumes:
-      - kafka-data:/bitnami/kafka
-    depends_on:
-      - zookeeper
-    logging:
-      driver: none
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_NUM_PARTITIONS: 1
 
 volumes:
   kafka-data:

--- a/src/k2eg/controller/node/worker/snapshot/BackTimedBufferedSnapshotOpInfo.h
+++ b/src/k2eg/controller/node/worker/snapshot/BackTimedBufferedSnapshotOpInfo.h
@@ -70,6 +70,9 @@ class BackTimedBufferedSnapshotOpInfo : public SnapshotOpInfo
     std::unordered_set<std::string>                    all_pvs_;        // full PV set for this snapshot
     std::unordered_set<std::string>                    pvs_no_events_;  // PVs that did not receive any event in the current window
     std::unordered_map<std::string, std::uint64_t>     events_per_pv_;  // counter of events per PV in the current window
+    // Snapshot of silent PVs captured before stats reset on full window expiration
+    mutable std::vector<std::string>                   pending_pvs_without_events_;
+    mutable bool                                       pending_pvs_without_events_ready_ = false;
 public:
     // Buffer to store all received values during the time window
     std::map<std::string, std::vector<k2eg::service::epics_impl::MonitorEventShrdPtr>> value_buffer;


### PR DESCRIPTION
- reset pending silent PV cache when initializing the window

- snapshot quiet PVs on expiration so downstream callers see the last set

- clear the pending list when forced expiration skips timeout handling